### PR TITLE
Fix build with Nixpkgs master

### DIFF
--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -18,7 +18,7 @@ extra-source-files:  README.md
 
 executable nix-diff
   main-is:             Main.hs
-  build-depends:       base             >= 4.9  && < 4.10
+  build-depends:       base             >= 4.9  && < 4.11
                      , attoparsec       >= 0.13 && < 0.14
                      , containers       >= 0.5  && < 0.6
                      , Diff             >= 0.3  && < 0.4


### PR DESCRIPTION
Otherwise the build fails with:
```
Setup: Encountered missing dependencies:
base ==4.9.*
```