### PR TITLE
Relax containers upper bound.

### DIFF
--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -20,7 +20,7 @@ executable nix-diff
   main-is:             Main.hs
   build-depends:       base                 >= 4.9      && < 5
                      , attoparsec           >= 0.13     && < 0.14
-                     , containers           >= 0.5      && < 0.6
+                     , containers           >= 0.5      && < 0.7
                      , Diff                 >= 0.3      && < 0.4
                      , text                 >= 1.2      && < 1.3
                      , system-filepath      >= 0.4      && < 0.5


### PR DESCRIPTION
Fixes build with current Nixpkgs master which now tracks LTS 13 with GHC 8.6.x.