### PR TITLE
Fix build and upgrade deps

### DIFF
--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -21,10 +21,10 @@ executable nix-diff
   build-depends:       base                 >= 4.9      && < 5
                      , attoparsec           >= 0.13     && < 0.14
                      , containers           >= 0.5      && < 0.7
-                     , Diff                 >= 0.3      && < 0.4
+                     , Diff                 >= 0.3      && < 0.5
                      , text                 >= 1.2      && < 1.3
                      , system-filepath      >= 0.4      && < 0.5
-                     , optparse-applicative >= 0.14.0.0 && < 0.15
+                     , optparse-applicative >= 0.14.0.0 && < 0.16
                      , nix-derivation       >= 1.0      && < 1.1
                      , mtl                  >= 2.2      && < 2.3
                      , unix                                < 2.8

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -40,6 +40,10 @@ import qualified Options.Applicative
 import qualified System.Posix.IO
 import qualified System.Posix.Terminal
 
+#if MIN_VERSION_base(4,9,0)
+import Control.Monad.Fail (MonadFail)
+#endif
+
 data Color = Always | Auto | Never
 
 parseColor :: Parser Color

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE CPP                        #-}
 
 module Main where
 
@@ -130,6 +131,9 @@ newtype Diff a = Diff { unDiff :: ReaderT Context (StateT Status IO) a }
     , MonadReader Context
     , MonadState Status
     , MonadIO
+#if MIN_VERSION_base(4,9,0)
+    , MonadFail
+#endif
     )
 
 echo :: Text -> Diff ()


### PR DESCRIPTION
* Derive `MonadFail` for `Diff`. Otherwise we hit the following on GHC-8.8.2:
```
src/Main.hs:186:13: error:
  • No instance for (MonadFail Diff) arising from a use of ‘fail’
```

*  `nix-diff.cabal`: allow `Diff-0.4` and `optparse-applicative-0.15`.
I tested the build with the following configuration:
```
Configuring nix-diff-1.0.8...
Dependency Diff >=0.3 && <0.5: using Diff-0.4.0
Dependency optparse-applicative >=0.14.0.0 && <0.16: using optparse-applicative-0.15.1.0
...
```