### PR TITLE
GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: "actions/checkout@v1"
+      - id: setup-haskell-cabal
+        uses: "haskell/actions/setup@v1.2"
+        with:
+          cabal-version: "${{ matrix.cabal }}"
+          enable-stack: false
+          ghc-version: "${{ matrix.ghc }}"
+      - uses: "actions/cache@v1"
+        with:
+          key: "${{ runner.os }}-${{ matrix.ghc }}-cabal"
+          path: "${{ steps.setup-haskell-cabal.outputs.cabal-store }}"
+      - name: Install dependencies
+        run: |
+          cabal update
+          cabal build --enable-tests --enable-benchmarks --only-dependencies
+      - name: build
+        run: cabal build --enable-tests --enable-benchmarks
+      - name: test
+        run: cabal test --enable-tests
+    strategy:
+      matrix:
+        cabal:
+          - '3.2'
+        ghc:
+          - '8.10.4'
+          - '8.8.4'
+          - '8.6.5'
+          - '9.0.1'
+name: Haskell CI
+on:
+  - push
+  - pull_request

--- a/ci.dhall
+++ b/ci.dhall
@@ -1,0 +1,30 @@
+let haskellCi =
+      https://raw.githubusercontent.com/sorki/github-actions-dhall/pending/haskell-ci.dhall
+
+let Prelude = https://prelude.dhall-lang.org/package.dhall
+
+let matrixStepsNoHaddoc =
+      let steps = haskellCi.matrixSteps
+
+      in  Prelude.List.take
+            ( Prelude.Natural.subtract
+                1
+                (Prelude.List.length haskellCi.BuildStep steps)
+            )
+            haskellCi.BuildStep
+            steps
+
+in        haskellCi.generalCi
+            matrixStepsNoHaddoc
+            ( Some
+                { ghc =
+                  [ haskellCi.GHC.GHC8104
+                  , haskellCi.GHC.GHC884
+                  , haskellCi.GHC.GHC865
+                  , haskellCi.GHC.GHC901
+                  ]
+                , cabal = [ haskellCi.Cabal.Cabal32 ]
+                }
+            )
+      //  { on = [ haskellCi.Event.push, haskellCi.Event.pull_request ] }
+    : haskellCi.CI.Type

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Script by @fisx
+
+set -eo pipefail
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+echo "regenerating .github/workflows/ci.yaml..."
+
+# based on https://github.com/vmchale/github-actions-dhall
+which dhall-to-yaml || cabal install dhall-yaml
+dhall-to-yaml --file ci.dhall > .github/workflows/ci.yaml


### PR DESCRIPTION
Using my hopefully temporary fork of https://github.com/vmchale/github-actions-dhall

from https://github.com/vmchale/github-actions-dhall/compare/master...sorki:pending

Build steps needs filtering but it quickly gets ugly due to
https://github.com/dhall-lang/dhall-lang/issues/961 so we hack around
this and instead do `init` on build steps which just leaves out `haddoc`
step.

--

I've noticed that this is still using Travis, so gave it a shot, using dhall for some additional dogfooding :smile: 