### PR TITLE
Accept realised store paths as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ nix-diff /nix/store/6z9nr5pzs4j1v9mld517dmlcz61zy78z-nixos-system-nixos-18.03p
 
 It's also possible to pass store paths or links to store paths, for example:
 
-```bash
+```ShellSession
 $ nix-build example.nix
 $ nix-diff /run/current-system ./result
 ```

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ $ nix-diff /nix/store/6z9nr5pzs4j1v9mld517dmlcz61zy78z-nixos-system-nixos-18.03p
 
 ![](https://i.imgur.com/KUB4rXx.png)
 
+It's also possible to pass store paths or links to store paths, for example:
+
+```bash
+$ nix-build example.nix
+$ nix-diff /run/current-system ./result
+```
+
 ## Development status
 
 [![Build Status](https://travis-ci.org/Gabriel439/nix-diff.png)](https://travis-ci.org/Gabriel439/nix-diff)

--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -30,8 +30,8 @@ executable nix-diff
                      , text                 >= 1.2      && < 1.3
                      , unix                                < 2.8
                      , vector               >= 0.12     && < 0.13
-                     , process
-                     , filepath
+                     , process                             < 1.7
+                     , filepath                            < 1.5
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -31,6 +31,7 @@ executable nix-diff
                      , unix                                < 2.8
                      , vector               >= 0.12     && < 0.13
                      , process
+                     , filepath
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -30,6 +30,7 @@ executable nix-diff
                      , text                 >= 1.2      && < 1.3
                      , unix                                < 2.8
                      , vector               >= 0.12     && < 0.13
+                     , process
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
The tool still accepts `.drv` files as input but also realised (built) paths.

It's possible to ask for the derivation corresponding to a store path with

    nix-store -qd store-path

Nix also takes care of following symbolic links.

The motivation is being able to easily compare a newly built system with the currently running system:

    nix-diff /run/current-system $result