### PR TITLE
Fix parsing .drv and .nix files that contain non utf-8 bytes

### DIFF
--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -21,6 +21,7 @@ executable nix-diff
   main-is:             Main.hs
   build-depends:       base                 >= 4.9      && < 5
                      , attoparsec           >= 0.13     && < 0.14
+                     , bytestring           >= 0.9      && < 0.12
                      , containers           >= 0.5      && < 0.7
                      , directory                           < 1.4
                      , mtl                  >= 2.2      && < 2.3


### PR DESCRIPTION
See comment in function.

`Text.IO.readFile` would actually not even decode utf8, it would use
the current locale to parse files, which is a bad assumption. Usually
nix source code, strings etc. are assumed to be utf-8, so we can
assume utf-8 as well.

Fixes https://github.com/Gabriel439/nix-diff/issues/49